### PR TITLE
Refactor configuration handling and update README

### DIFF
--- a/confx.go
+++ b/confx.go
@@ -19,7 +19,7 @@ import (
 	"github.com/spf13/viper"
 )
 
-type Loader[T any] func(ctx context.Context, path string) (T, error)
+type Loader[T any] func(ctx context.Context, confPath string) (T, error)
 
 // Initialize sets up configuration binding by automatically registering command-line flags,
 // binding environment variables, loading configuration files, and validating the final configuration.

--- a/decode.go
+++ b/decode.go
@@ -120,7 +120,7 @@ func parseSlice[T any](parts []string, parseFunc func(string) (T, error)) ([]T, 
 func StringToMapHookFunc(separator string, pairSeparator string) mapstructure.DecodeHookFunc {
 	return func(from reflect.Type, to reflect.Type, data any) (any, error) {
 		if from.Kind() == reflect.String && to.Kind() == reflect.Map {
-			str := strings.Trim(data.(string), "[]")
+			str := strings.Trim(data.(string), "[]{}")
 			if str == "" {
 				return reflect.MakeMap(to).Interface(), nil
 			}


### PR DESCRIPTION
- Renamed parameter in Loader type from 'path' to 'confPath' for clarity.
- Updated StringToMapHookFunc to trim both square and curly braces from strings.
- Revised README to streamline configuration examples and clarify usage of embedded default configuration.
- Removed outdated configuration file examples and added new YAML structure for clarity.